### PR TITLE
Refactor getHealthMetrics method

### DIFF
--- a/example/src/screens/Playground.tsx
+++ b/example/src/screens/Playground.tsx
@@ -5,15 +5,15 @@ import PointSdkRn from 'react-native-point-sdk';
 export function PlaygroundScreen() {
   const getUserHealthMetrics = async () => {
     try {
-      const data = await PointSdkRn.getUserHealthMetrics(
-        [
+      const data = await PointSdkRn.getHealthMetrics({
+        filter: [
           'Vo2Max',
           'TotalWorkoutDuration',
           'TotalMinsHRZone12',
           'TotalMinsHRZone34',
         ],
-        new Date().toISOString(),
-      );
+        date: new Date('2022-05-10').toISOString(),
+      });
       console.log(data);
     } catch (error) {
       console.log(error);

--- a/index.d.ts
+++ b/index.d.ts
@@ -191,7 +191,11 @@ export function rateWorkout(id: number, ratings: WorkoutRatings): Promise<Workou
 export function getDailyHistory(offset: number): Promise<[{ date: Date; metrics: HealthMetric[] }]>;
 export function setUserGoal(goal: Goal): Promise<User>;
 export function setUserSpecificGoal(specificGoal: SpecificGoal): Promise<User>;
-export function getUserHealthMetrics(filter: HealthMetricType[], date: string): Promise<HealthMetric[]>;
+export function getHealthMetrics(params: {
+  filter?: HealthMetricType[];
+  workoutId?: number;
+  date?: string;
+}): Promise<HealthMetric[]>;
 export function getUserRecommendations(): Promise<Recommendation[]>;
 export function recommendationSeen(id: number): Promise<any>;
 export function getUserTrends(): Promise<Trend[]>;

--- a/ios/PointSdkRn+DataManager.swift
+++ b/ios/PointSdkRn+DataManager.swift
@@ -235,17 +235,18 @@ import PointSDK
   }
   
   /**
-   *  getUserHealthMetrics  Retrieve user metrics
-   *  @param array          filter
-   *  @param int            workoutId
-   *  @param string         date
-   *  @param resolve        Resolve handler
-   *  @param reject         Reject handler
+   *  getHealthMetrics Retrieve health metrics
+   *  @param object    Params
+   *  @param resolve   Resolve handler
+   *  @param reject    Reject handler
    */
   @objc
-  func getUserHealthMetrics(_ filter: Array<String>?, date: String, resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+  func getHealthMetrics(_ params: [String : Any], resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
     Task {
       do {
+        let filter = params["filter"] as? [String]
+        let workoutId = params["workoutId"] as? Int
+        let date = params["date"] as? String
         var healthMetrics = HealthMetric.Kind.allCases
 
         if let filter = filter {
@@ -254,13 +255,13 @@ import PointSDK
 
         let data = try await dataManager?.getHealthMetrics(
           filter: Set(healthMetrics),
-          workoutId: nil,
-          date: date.fromIsoStringToDate()
+          workoutId: workoutId,
+          date: date?.fromIsoStringToDate()
         )
 
         resolve(data?.map { metricMapping(metric: $0) })
       } catch {
-        reject("getUserHealthMetrics", error.localizedDescription, error)
+        reject("getHealthMetrics", error.localizedDescription, error)
       }
     }
   }

--- a/ios/PointSdkRnBridge.m
+++ b/ios/PointSdkRnBridge.m
@@ -22,7 +22,7 @@ RCT_EXTERN_METHOD(getWorkoutRecommendations:(NSString)date resolve: (RCTPromiseR
 RCT_EXTERN_METHOD(saveWorkoutRecommendation:(NSInteger)id resolve: (RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(setUserGoal:(NSString)goal resolve: (RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(setUserSpecificGoal:(NSString)specificGoal resolve: (RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject);
-RCT_EXTERN_METHOD(getUserHealthMetrics:(NSArray *)filter date: (NSString *)date resolve: (RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject);
+RCT_EXTERN_METHOD(getHealthMetrics:(NSDictionary *)params resolve: (RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(getUserRecommendations:(RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(recommendationSeen:(NSInteger)id resolve: (RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject);
 


### PR DESCRIPTION
This PR covers the following changes:
- rename method from `getUserHealthMetrics` to `getHealthMetrics`
- adapt method to received a dictionary instead of specific params