### PR TITLE
Android: Add the getUserWorkoutById function

### DIFF
--- a/android/src/main/java/com/pointsdkrn/PointSdkRepository.kt
+++ b/android/src/main/java/com/pointsdkrn/PointSdkRepository.kt
@@ -41,6 +41,17 @@ internal class PointSdkRepository(
         }
     }
 
+    fun getUserWorkoutById(workoutId: Int, promise: Promise) {
+        GlobalScope.launch(Dispatchers.IO) {
+            try {
+                val workout = pointRepository.getWorkout(workoutId).toResponse()
+                promise.resolve(workout)
+            } catch (ex: PointException) {
+                promise.reject("PointSDKError", ex.message)
+            }
+        }
+    }
+
     fun getHealthMetrics(
         filter: List<HealthMetricType>,
         workoutId: Int?,

--- a/android/src/main/java/com/pointsdkrn/PointSdkRn.kt
+++ b/android/src/main/java/com/pointsdkrn/PointSdkRn.kt
@@ -82,6 +82,11 @@ class PointSdkRn(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun getUserWorkoutById(id: Int, promise: Promise) {
+        pointSdkRepository.getUserWorkoutById(id, promise)
+    }
+
+    @ReactMethod
     fun getDailyHistory(offset: Int?, promise: Promise) {
         pointSdkRepository.getDailyHistory(offset ?: 0, promise)
     }


### PR DESCRIPTION
[Pivotal Tracker](https://www.pivotaltracker.com/story/show/183642406)
This one is not being called by the example app, so I did some very hacky workarounds to test it, but I confirmed it's working  exactly like `getUserWorkouts`, though some of workouts returned there are currently giving me a 400 error on the by id endpoint, but I'm guessing it's a development data issue.
Here's a sample response:
```JSON
{
	"activityName": "Walking",
	"end": "2022-11-19T13:02:48.778Z",
	"duration": 2064,
	"ratings": { "instructor": 17, "energy": 94, "difficulty": 23 },
	"distance": 1.17930805742708,
	"start": "2022-11-19T12:28:24.358Z",
	"activityId": 52,
	"calories": 128.120449790469,
	"id": 23340
}
```