### PR TITLE
Android: add the rateWorkout function

### DIFF
--- a/android/src/main/java/com/pointsdkrn/Mappers.kt
+++ b/android/src/main/java/com/pointsdkrn/Mappers.kt
@@ -45,6 +45,12 @@ fun WorkoutRatings.toResponse(): WritableMap =
         putIntOrNull("instructor", instructor)
     }
 
+fun ReadableMap.toWorkoutRatings() = WorkoutRatings(
+    difficulty = getNullableInt("difficulty"),
+    energy = getNullableInt("energy"),
+    instructor = getNullableInt("instructor")
+)
+
 fun GoalProgress.toResponse(): WritableMap =
     Arguments.createMap().apply {
         putMap("endurance", endurance.toResponse())
@@ -126,6 +132,9 @@ fun <E : ReadableMap> List<E>.toReadableArray(): ReadableArray {
     this.forEach { response.pushMap(it) }
     return response
 }
+
+fun ReadableMap.getNullableInt(name: String) =
+    if (this.hasKey(name)) this.getInt(name) else null
 
 fun WritableMap.putIntOrNull(key: String, value: Int?) =
     if (value != null) putInt(key, value) else putNull(key)

--- a/android/src/main/java/com/pointsdkrn/PointSdkRepository.kt
+++ b/android/src/main/java/com/pointsdkrn/PointSdkRepository.kt
@@ -4,6 +4,7 @@ import co.areyouonpoint.pointsdk.domain.PointRepository
 import co.areyouonpoint.pointsdk.domain.exceptions.PointException
 import co.areyouonpoint.pointsdk.domain.model.HealthMetricType
 import co.areyouonpoint.pointsdk.domain.model.InsightType
+import co.areyouonpoint.pointsdk.domain.model.WorkoutRatings
 import com.facebook.react.bridge.Promise
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -115,6 +116,18 @@ internal class PointSdkRepository(
                     .toReadableArray()
 
                 promise.resolve(insights)
+            } catch (ex: PointException) {
+                promise.reject("PointSDKError", ex.message)
+            }
+        }
+    }
+
+    fun rateWorkout(workoutId: Int, workoutRatings: WorkoutRatings, promise: Promise) {
+        GlobalScope.launch(Dispatchers.IO) {
+            try {
+                val workout = pointRepository.getWorkout(workoutId)
+                val newWorkout = pointRepository.rateWorkout(workout, workoutRatings).toResponse()
+                promise.resolve(newWorkout)
             } catch (ex: PointException) {
                 promise.reject("PointSDKError", ex.message)
             }

--- a/android/src/main/java/com/pointsdkrn/PointSdkRn.kt
+++ b/android/src/main/java/com/pointsdkrn/PointSdkRn.kt
@@ -114,6 +114,13 @@ class PointSdkRn(reactContext: ReactApplicationContext) :
 
         return pointSdkRepository.getInsights(types, startDate, endDate, offset, promise)
     }
+
+    @ReactMethod
+    fun rateWorkout(id: Int, ratings: ReadableMap, promise: Promise) {
+        val workoutRatings = ratings.toWorkoutRatings()
+
+        return pointSdkRepository.rateWorkout(id, workoutRatings, promise)
+    }
 }
 
 private fun environmentsMapping(env: String): PointEnvironment {
@@ -125,6 +132,3 @@ private fun environmentsMapping(env: String): PointEnvironment {
         else -> PointEnvironment.DEVELOPMENT
     }
 }
-
-private fun ReadableMap.getNullableInt(name: String) =
-    if (this.hasKey(name)) this.getInt(name) else null


### PR DESCRIPTION
[Pivotal Tracker](https://www.pivotaltracker.com/story/show/183642430)

Here's a sample response: (Less useful here because this function is meant for writing, not reading, but why not?)
```JSON
{
	"activityName": "Running",
	"end": "2022-11-23T16:36:00.000Z",
	"duration": 120,
	"ratings": { "instructor": 3, "energy": 2, "difficulty": 1 },
	"distance": 0.621371192237334,
	"start": "2022-11-23T16:34:00.000Z",
	"activityId": 37,
	"calories": 100,
	"id": 23451
}
```